### PR TITLE
Fix GitHub star counter

### DIFF
--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -21,6 +21,6 @@
 </div>
 
 <div style="text-align: center;" width="100%">
-  <iframe src="http://ghbtns.com/github-btn.html?user=scikit-image&repo=scikit-image&type=watch&count=true"
-    allowtransparency="true" frameborder="0" scrolling="0" width="110" display="inline-block" height="20"></iframe>
+  <iframe src="https://ghbtns.com/github-btn.html?user=scikit-image&repo=scikit-image&type=star&count=true"
+    frameborder="0" scrolling="0" width="110" display="inline-block" height="20"></iframe>
 </div>


### PR DESCRIPTION
Fixes GitHub star counter on the main page of the website (see https://github.com/scikit-image/skimage-web/pull/79#issuecomment-1266517160).

Updates the widget component (URL and parameters) according to the latest template (https://ghbtns.com/#star).
