### PR TITLE
Resolves search conflict in the API Documentation

### DIFF
--- a/themes/scikit-image/layout.html
+++ b/themes/scikit-image/layout.html
@@ -87,7 +87,7 @@
             <ul class="nav">
                 {% include 'navbar.html' %}
             </ul>
-            <form class="navbar-form pull-right" action="/docs/dev/search.html" method="get">
+            <form class="navbar-form pull-right" action="/docs/stable/search.html" method="get">
                 <input type="text" class="search span3" name="q" placeholder="Search documentation ...">
                 <input type="hidden" name="check_keywords" value="yes" >
                 <input type="hidden" name="area" value="default" >


### PR DESCRIPTION
Addresses the issue #83

The search bar is issuing GET requests to dev URL instead of the stable URL.
GET request to the stable URL should fix the issue. 
The action corresponding to the search bar element was modified to point to the stable URL.