### PR TITLE
Re-add missing raw html directive

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -5,6 +5,8 @@
 
 .. container:: well hero row-fluid summary-box
 
+   .. raw:: html
+
       <h2>Image processing in Python</h2>
 
    *scikit-image* is a collection of algorithms for image processing.  It


### PR DESCRIPTION
Currently the website renders wrong

![image](https://github.com/scikit-image/skimage-web/assets/20140352/40a185e5-ae20-4f93-8bb2-87ec5384d283)

because the `.. raw:: html` directive was accidentially removed as well in  6d76fcc2104370a087adc7ad5e77ea2a140ac821. This should remedy that.

