### PR TITLE
Update index.rst to remove the redundant and non-functioning download button

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -22,11 +22,6 @@
    peer-reviewed code, written by an active `community of volunteers
    <https://www.openhub.net/p/scikit-image/contributors>`__.
 
-   .. raw:: html
-
-      <a class="btn btn-warning clearfix" href="/docs/stable/install.html">
-      <i class="icon-download icon-white"></i>Download</a>
-
 .. container:: well hero row-fluid summary-box citation
 
     .. raw:: html


### PR DESCRIPTION
Hello, 
This PR is to remove the orange download button on the homepage of the docs i.e., https://scikit-image.org/ which is
1. redundant because there are download buttons on the left side for the stable and development versions and 
2. non-functioning because it directs to   
`https://scikit-image.org/docs/stable/install.html` instead of   
`https://scikit-image.org/docs/stable/user_guide/install.html`

![image](https://github.com/scikit-image/skimage-web/assets/9945034/8e443997-10d5-42b6-b833-5f03af988b64)
