### PR TITLE
Fix broken link to user guide by removing the html extension

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -87,7 +87,7 @@ visit our `gallery </docs/dev/auto_examples>`__.
       .. image:: _static/sobel-coins-small.png
          :class: coins-sample span6
 
-You can read more in our `user guide </docs/stable/user_guide.html>`__.
+You can read more in our `user guide </docs/stable/user_guide>`__.
 For an introduction to image processing using scikit-image, see
 `this lesson <https://datacarpentry.org/image-processing/>`__ by Data Carpentry.
 

--- a/index.rst
+++ b/index.rst
@@ -87,7 +87,7 @@ visit our `gallery </docs/dev/auto_examples>`__.
       .. image:: _static/sobel-coins-small.png
          :class: coins-sample span6
 
-You can read more in our `user guide </docs/stable/user_guide>`__.
+You can read more in our `user guide </docs/stable/user_guide/>`__.
 For an introduction to image processing using scikit-image, see
 `this lesson <https://datacarpentry.org/image-processing/>`__ by Data Carpentry.
 


### PR DESCRIPTION
Hello, this PR is to address https://github.com/scikit-image/scikit-image/issues/7068.  